### PR TITLE
Make it work on systemcore

### DIFF
--- a/external_samples/component.py
+++ b/external_samples/component.py
@@ -33,7 +33,7 @@ class InvalidPortException(Exception):
 class Component(ABC):
     def __init__(self, port : Port, expectedType : PortType):
         """This has the port it is attached to, and the expected type of the port"""
-        if port.get_type != expectedType:
+        if port.get_type() != expectedType:
             raise InvalidPortException
 
         self.port = port

--- a/external_samples/port.py
+++ b/external_samples/port.py
@@ -32,12 +32,12 @@ class PortType(Enum):
     USB_HUB = BASE_COMPOUND + 1
     EXPANSION_HUB_MOTOR = BASE_COMPOUND + 2
     EXPANSION_HUB_SERVO = BASE_COMPOUND + 3
-    
+
 class Port:
-    def __init__(self, port_type : PortType = None, location : int = None, port1 : type[Self] = None, port2 : type[Self] = None):
+    def __init__(self, port_type: PortType = None, location: int = None, port1: type[Self] = None, port2: type[Self] = None):
         """
         Create a port that can be either simple (type + location) or compound (two other ports).
-        
+
         Args:
             port_type: PortType or CompoundPortType for this port
             location: int location for simple ports
@@ -46,7 +46,7 @@ class Port:
         """
         if port1 is not None and port2 is not None:
             # Compound port
-            if port_type < PortType.BASE_COMPOUND:
+            if port_type.value < PortType.BASE_COMPOUND.value:
                 raise ValueError("Port must be of a compound type")
             self.is_compound = True
             self.type = port_type
@@ -55,8 +55,8 @@ class Port:
             self.location = None
         elif port_type is not None and location is not None:
             # Simple port
-            if port_type > PortType.BASE_COMPOUND:
-                raise ValueError("Port must be of a simple type")            
+            if port_type.value > PortType.BASE_COMPOUND.value:
+                raise ValueError("Port must be of a simple type")
             self.is_compound = False
             self.type = port_type
             self.location = location
@@ -64,23 +64,19 @@ class Port:
             self.port2 = None
         else:
             raise ValueError("Port must be either simple (type + location) or compound (port1 + port2)")
-    
-    def get_all_ports(self):
+
+    def get_all_ports(self) -> list[tuple[PortType, int]]:
         """Return a list of all simple ports contained in this port."""
         if self.is_compound:
             return self.port1.get_all_ports() + self.port2.get_all_ports()
         else:
             return [(self.type, self.location)]
-    
 
-    def get_type(self):
-        """This returns the type if it is simple or the type of the last one in the chain if compound"""
-        if self.is_compound:
-            return self.port2.get_type()
-        else:
-            return self.type           
+    def get_type(self) -> PortType:
+        """Returns the port type"""
+        return self.type
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.is_compound:
             return f"CompoundPort({self.type}: {self.port1}, {self.port2})"
         else:

--- a/src/blocks/mrc_port.ts
+++ b/src/blocks/mrc_port.ts
@@ -111,9 +111,11 @@ export const setup = function () {
 
 export const pythonFromBlock = function (
     block: PortBlock,
-    _generator: ExtendedPythonGenerator) {
-  const ports: string[] = [];
+    generator: ExtendedPythonGenerator) {
+  generator.addImport('port');
   
+  const ports: string[] = [];
+
   for (let i = 0; i < block.inputList.length; i++) {
     const input = block.inputList[i];
     if (input.name.startsWith('PORT_')) {
@@ -123,32 +125,32 @@ export const pythonFromBlock = function (
       }
     }
   }
-  let code = `Port(port_type = PortType.${block.portType_}, `;
+  let code = `port.Port(port_type = port.PortType.${block.portType_}, `;
   
-  if ( ports.length === 1 ) {
+  if (ports.length === 1) {
      code += `location = ${ports[0]})`;
-  }
-  else if ( ports.length === 2 ) {
+
+  } else if (ports.length === 2) {
     let port1Type = 'UNKNOWN';
     let port2Type = 'UNKNOWN';
 
-    switch(block.portType_){
+    switch (block.portType_) {
       case 'USB_HUB':
         port1Type = 'USB_PORT';
         port2Type = 'USB_PORT';
         break;
       case 'EXPANSION_HUB_MOTOR':
         port1Type = 'USB_PORT';
-        port2Type = 'MOTOR_PORT';
+        port2Type = 'EXPANSION_HUB_MOTOR_PORT';
         break;
       case 'EXPANSION_HUB_SERVO':
         port1Type = 'USB_PORT';
-        port2Type = 'SERVO_PORT';
+        port2Type = 'EXPANSION_HUB_SERVO_PORT';
         break;
     }
 
-    code += `\\ \n${_generator.INDENT}port1 = Port(port_type = PortType.${port1Type}, location = ${ports[0]}), `;
-    code += `\\ \n${_generator.INDENT}port2 = Port(port_type = PortType.${port2Type}, location = ${ports[1]}))`;
+    code += `\\ \n${generator.INDENT}port1 = port.Port(port_type = port.PortType.${port1Type}, location = ${ports[0]}), `;
+    code += `\\ \n${generator.INDENT}port2 = port.Port(port_type = port.PortType.${port2Type}, location = ${ports[1]}))`;
   }
 
   return [code, Order.ATOMIC];

--- a/src/blocks/utils/generated/external_samples_data.json
+++ b/src/blocks/utils/generated/external_samples_data.json
@@ -1226,7 +1226,7 @@
                     "declaringClassName": "port.Port",
                     "functionName": "__init__",
                     "returnType": "port.Port",
-                    "tooltip": "\nCreate a port that can be either simple (type + location) or compound (two other ports).\n\nArgs:\n    port_type: PortType or CompoundPortType for this port\n    location: int location for simple ports\n    port1: First Port for compound ports\n    port2: Second Port for compound ports\n"
+                    "tooltip": "\n        Create a port that can be either simple (type + location) or compound (two other ports).\n\n        Args:\n            port_type: PortType or CompoundPortType for this port\n            location: int location for simple ports\n            port1: First Port for compound ports\n            port2: Second Port for compound ports\n        "
                 }
             ],
             "enums": [],
@@ -1241,7 +1241,7 @@
                     ],
                     "declaringClassName": "port.Port",
                     "functionName": "get_all_ports",
-                    "returnType": "None",
+                    "returnType": "list[tuple[port.PortType, int]]",
                     "tooltip": "Return a list of all simple ports contained in this port."
                 },
                 {
@@ -1254,8 +1254,8 @@
                     ],
                     "declaringClassName": "port.Port",
                     "functionName": "get_type",
-                    "returnType": "None",
-                    "tooltip": "This returns the type if it is simple or the type of the last one in the chain if compound"
+                    "returnType": "port.PortType",
+                    "tooltip": "Returns the port type"
                 }
             ],
             "instanceVariables": [],


### PR DESCRIPTION
Make it work on systemcore.

In port.py:
When compare port_type with PortType.BASE_COMPOUND, use .value to get the numeric value. Added type hints for function returns.
Modified get_type to just return self.type.

In component.py:
Changed port.get_type to port.get_type().

In mrc_port.ts, in pythonFromBlock:
Changed _generator to generator.
Added generator.addImport('port');
Changed Port to port.Port in generated python code. Changed PortType to port.PortType in generated python code. Changed MOTOR_PORT to EXPANSION_HUB_MOTOR_PORT.
Changed SERVO_PORT to EXPANSION_HUB_SERVO_PORT.

Updated external_samples_data.json.